### PR TITLE
distances between cells and their neighbourhood

### DIFF
--- a/healpix_convolution/distances.py
+++ b/healpix_convolution/distances.py
@@ -31,6 +31,25 @@ def _distances(a, b, axis, nside, nest):
 
 
 def distances(neighbours, *, resolution, indexing_scheme="nested", axis=None):
+    """compute the angular great-circle distances between neighbours
+
+    Parameters
+    ----------
+    neighbours : array-like
+        The input cell ids.
+    resolution : int
+        The resolution of healpix pixelization.
+    indexing_scheme : {"nested", "ring"}, default: "nested"
+        The indexing scheme of the cell ids.
+    axis : int, optional
+        The axis used for the neighbours. If not given, assume the last dimension.
+
+    Returns
+    -------
+    distances : array-like
+        The great-circle distances in radians.
+    """
+
     if axis is None:
         axis = -1
 

--- a/healpix_convolution/distances.py
+++ b/healpix_convolution/distances.py
@@ -25,7 +25,7 @@ def _distances(a, b, axis, nside, nest):
     vec_b = np.where(mask[..., None], vec_b_, np.nan)
 
     dot_product = np.abs(np.sum(vec_a * vec_b, axis=axis))
-    cross_product = np.linalg.norm(np.cross(vec_a, vec_b, axis=-1), axis=axis)
+    cross_product = np.linalg.norm(np.cross(vec_a, vec_b, axis=axis), axis=axis)
 
     return np.arctan2(cross_product, dot_product)
 
@@ -41,7 +41,7 @@ def distances(neighbours, *, resolution, indexing_scheme="nested", axis=None):
         return da.map_blocks(
             _distances,
             neighbours[:, :1],
-            neighbours[:, 1:],
+            neighbours,
             axis=axis,
             nside=nside,
             nest=nest,
@@ -49,5 +49,5 @@ def distances(neighbours, *, resolution, indexing_scheme="nested", axis=None):
         )
     else:
         return _distances(
-            neighbours[:, :1], neighbours[:, 1:], axis=axis, nside=nside, nest=nest
+            neighbours[:, :1], neighbours, axis=axis, nside=nside, nest=nest
         )

--- a/healpix_convolution/distances.py
+++ b/healpix_convolution/distances.py
@@ -1,0 +1,53 @@
+import healpy as hp
+import numpy as np
+
+try:
+    import dask.array as da
+
+    dask_array_type = (da.Array,)
+except ImportError:
+    da = None
+    dask_array_type = ()
+
+
+def cell_ids2vectors(cell_ids, nside, nest):
+    flattened = cell_ids.flatten()
+    vecs = np.stack(hp.pix2vec(nside, flattened, nest=nest), axis=-1)
+    return np.reshape(vecs, cell_ids.shape + (3,))
+
+
+def _distances(a, b, axis, nside, nest):
+    vec_a = cell_ids2vectors(a, nside, nest)
+
+    # TODO: contains `-1`, which `pix2vec` doesn't like
+    mask = b != -1
+    vec_b_ = cell_ids2vectors(np.where(mask, b, 0), nside, nest)
+    vec_b = np.where(mask[..., None], vec_b_, np.nan)
+
+    dot_product = np.abs(np.sum(vec_a * vec_b, axis=axis))
+    cross_product = np.linalg.norm(np.cross(vec_a, vec_b, axis=-1), axis=axis)
+
+    return np.arctan2(cross_product, dot_product)
+
+
+def distances(neighbours, *, resolution, indexing_scheme="nested", axis=None):
+    if axis is None:
+        axis = -1
+
+    nest = indexing_scheme == "nested"
+    nside = 2**resolution
+
+    if isinstance(neighbours, dask_array_type):
+        return da.map_blocks(
+            _distances,
+            neighbours[:, :1],
+            neighbours[:, 1:],
+            axis=axis,
+            nside=nside,
+            nest=nest,
+            chunks=neighbours.chunks,
+        )
+    else:
+        return _distances(
+            neighbours[:, :1], neighbours[:, 1:], axis=axis, nside=nside, nest=nest
+        )

--- a/healpix_convolution/tests/test_distances.py
+++ b/healpix_convolution/tests/test_distances.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+
+import healpix_convolution.distances as hds
+
+
+@pytest.mark.parametrize(
+    ["neighbours", "expected"],
+    (
+        (np.array([[1, 0, 2, 3]]), np.array([[0, 0.25637566, 0.3699723, 0.25574741]])),
+        (np.array([[2, 71, 8]]), np.array([[0, 0.25637566, 0.25574741]])),
+    ),
+)
+def test_distances_numpy(neighbours, expected):
+    actual = hds.distances(neighbours, resolution=2, indexing_scheme="nested")
+
+    np.testing.assert_allclose(actual, expected)


### PR DESCRIPTION
The neighbours returned by the neighbour search have the original cell as the first value (from `ring=0`).

With that, the function:
- converts the cell ids to vectors
- computes the dot and cross products between the vector to the original cell and all others
- calls `np.arctan2` to determine the angular great-circle distances, and returns the result

If we pass a `dask` array, that function is instead applied per chunk.