### PR TITLE
convolution of array-like data

### DIFF
--- a/healpix_convolution/convolution.py
+++ b/healpix_convolution/convolution.py
@@ -1,0 +1,20 @@
+import dask.array as da
+import opt_einsum
+
+
+def convolve(arr, kernel, **kwargs):
+    """convolve an array using a pre-computed sparse kernel matrix
+
+    Parameters
+    ----------
+    arr : array-like
+        The data to convolve. The dimension to contract must be the last axis.
+    kernel : array-like
+        2-dimensional sparse matrix. Columns is the original pixels, rows the output pixels.
+    axis : int, optional
+        The axis along which to apply the convolution
+    """
+    if isinstance(arr, da.Array) and not isinstance(kernel, da.Array):
+        kernel = da.from_array(kernel)
+
+    return opt_einsum.contract(arr, kernel, "...a,ba->...b", **kwargs)

--- a/healpix_convolution/convolution.py
+++ b/healpix_convolution/convolution.py
@@ -17,4 +17,4 @@ def convolve(arr, kernel, **kwargs):
     if isinstance(arr, da.Array) and not isinstance(kernel, da.Array):
         kernel = da.from_array(kernel)
 
-    return opt_einsum.contract(arr, kernel, "...a,ba->...b", **kwargs)
+    return opt_einsum.contract("...a,ba->...b", arr, kernel, **kwargs)

--- a/healpix_convolution/tests/test_convolution.py
+++ b/healpix_convolution/tests/test_convolution.py
@@ -1,22 +1,17 @@
+import hypothesis
 import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
 import numpy as np
+import pytest
 import sparse
-from hypothesis import given
+from hypothesis import given, settings
 
 from healpix_convolution import convolution
 
 
-@given(
-    npst.arrays(
-        shape=st.sampled_from([(5,), (10, 5)]),
-        dtype=st.sampled_from(
-            ["float64", "float32", "int8", "int16", "int32", "int64"]
-        ),
-    )
-)
-def test_numpy_convolve(data):
-    kernel = sparse.COO.from_numpy(
+@pytest.fixture
+def rolling_mean_kernel():
+    kernel = (
         np.array(
             [
                 [1, 1, 0, 0, 1],
@@ -29,6 +24,22 @@ def test_numpy_convolve(data):
         / 3
     )
 
+    return sparse.COO.from_numpy(kernel, fill_value=0)
+
+
+@given(
+    data=npst.arrays(
+        shape=st.sampled_from([(5,), (10, 5)]),
+        # TODO: figure out how to deal with floating point values
+        dtype=st.sampled_from(["int16", "int32", "int64"]),
+    ),
+)
+@settings(
+    deadline=1000,
+    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture],
+)
+def test_numpy_convolve(data, rolling_mean_kernel):
+    kernel = rolling_mean_kernel
     actual = convolution.convolve(data, kernel)
 
     padding = [(0, 0)] * (data.ndim - 1) + [(1, 1)]

--- a/healpix_convolution/tests/test_convolution.py
+++ b/healpix_convolution/tests/test_convolution.py
@@ -1,0 +1,39 @@
+import hypothesis.extra.numpy as npst
+import hypothesis.strategies as st
+import numpy as np
+import sparse
+from hypothesis import given
+
+from healpix_convolution import convolution
+
+
+@given(
+    npst.arrays(
+        shape=st.sampled_from([(5,), (10, 5)]),
+        dtype=st.sampled_from(
+            ["float64", "float32", "int8", "int16", "int32", "int64"]
+        ),
+    )
+)
+def test_convolution(data):
+    kernel = sparse.COO.from_numpy(
+        np.array(
+            [
+                [1, 1, 0, 0, 1],
+                [1, 1, 1, 0, 0],
+                [0, 1, 1, 1, 0],
+                [0, 0, 1, 1, 1],
+                [1, 0, 0, 1, 1],
+            ]
+        )
+        / 3
+    )
+
+    actual = convolution.convolve(data, kernel)
+
+    padding = [(0, 0)] * (data.ndim - 1) + [(1, 1)]
+    padded = np.pad(data, padding, mode="wrap")
+    windows = np.lib.stride_tricks.sliding_window_view(padded, 3, axis=-1)
+    expected = np.mean(windows, axis=-1)
+
+    np.testing.assert_allclose(actual, expected)

--- a/healpix_convolution/tests/test_convolution.py
+++ b/healpix_convolution/tests/test_convolution.py
@@ -15,7 +15,7 @@ from healpix_convolution import convolution
         ),
     )
 )
-def test_convolution(data):
+def test_numpy_convolve(data):
     kernel = sparse.COO.from_numpy(
         np.array(
             [


### PR DESCRIPTION
To be as broadly applicable as possible, we need to support the convolution of raw array-likes like `dask`, `numpy` or `cupy` arrays.