### PR TITLE
pass the shape as a tuple to `reshape`

### DIFF
--- a/healpix_convolution/kernels/common.py
+++ b/healpix_convolution/kernels/common.py
@@ -3,17 +3,17 @@ import sparse
 
 
 def create_sparse(cell_ids, neighbours, weights, shape):
-    neighbours_ = np.reshape(neighbours, -1)
+    neighbours_ = np.reshape(neighbours, (-1,))
     mask = neighbours_ != -1
 
     n_neighbours = neighbours.shape[-1]
     cell_ids_ = np.reshape(
-        np.repeat(cell_ids[..., None], repeats=n_neighbours, axis=-1), -1
+        np.repeat(cell_ids[..., None], repeats=n_neighbours, axis=-1), (-1,)
     )
 
     coords = np.reshape(np.stack([cell_ids_, neighbours_], axis=0), (2, -1))
 
-    weights_ = np.reshape(weights, -1)[mask]
+    weights_ = np.reshape(weights, (-1,))[mask]
     coords_ = coords[..., mask]
 
     return sparse.COO(coords=coords_, data=weights_, shape=shape, fill_value=0)

--- a/healpix_convolution/kernels/gaussian.py
+++ b/healpix_convolution/kernels/gaussian.py
@@ -46,7 +46,7 @@ def gaussian_kernel(
             f"cell ids must be 1-dimensional, but shape is: {cell_ids.shape}"
         )
 
-    cell_ids = np.reshape(cell_ids, -1)
+    cell_ids = np.reshape(cell_ids, (-1,))
 
     # TODO: figure out whether there is a better way of defining the units of `sigma`
     if kernel_size is not None:


### PR DESCRIPTION
This allows the code to also work with `dask` / `cupy` (but because we're creating `sparse` arrays from that, additional work is necessary to allow going all the way).