### PR TITLE
ci diagnostics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,10 @@ jobs:
           conda info -a
           conda list
 
+      - name: Import healpix-convolution
+        run: |
+          python -c 'import healpix_convolution'
+
       - name: Restore cached hypothesis directory
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
To make sure the tests don't error out (with a reduced traceback), this adds a step that checks whether the library is still importable.