### PR TITLE
ci environment maintenance

### DIFF
--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -11,7 +11,6 @@ dependencies:
   - numpy
   - dask
   - healpy
-  - scipy<1.14 # healpy uses the removed `scipy.integrate.trapz`
   - geopandas
   - pandas
   - sparse

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -10,7 +10,7 @@ dependencies:
   - numba
   - numpy
   - dask
-  - healpy
+  - healpy>=1.17
   - geopandas
   - pandas
   - sparse


### PR DESCRIPTION
`healpy` got a new release on `conda-forge` yesterday, so some of the workarounds from before can be removed.