### PR TITLE
aggregating padding mode

### DIFF
--- a/healpix_convolution/padding.py
+++ b/healpix_convolution/padding.py
@@ -171,7 +171,6 @@ def pad(
         - "mean": pad with the mean of the neighbours.
         - "minimum": pad with the minimum of the neighbours.
         - "maximum": pad with the maximum of the neighbours.
-        - "median": pad with the median of the neighbours.
     constant_value : scalar, default: 0
         The constant value used in constant mode.
     end_value : scalar, default: 0
@@ -222,7 +221,6 @@ def pad(
         "mean": partial(agg_mode, agg=np.mean, ring=ring),
         "maximum": partial(agg_mode, agg=partial(np.max, initial=initial), ring=ring),
         "minimum": partial(agg_mode, agg=partial(np.min, initial=initial), ring=ring),
-        "median": partial(agg_mode, agg=np.median, ring=ring),
     }
 
     mode_func = modes.get(mode)

--- a/healpix_convolution/padding.py
+++ b/healpix_convolution/padding.py
@@ -182,6 +182,10 @@ def pad(
     padding_object : Padding
         The padding object. Can be used to apply the same padding operation for different
         arrays with the same geometry.
+
+    Warnings
+    --------
+    This assumes ``cell_ids`` is sorted, and will give wrong results if it is not.
     """
     # TODO: figure out how to allow reusing indices. How this works depends on the mode:
     # - in constant mode, we have:

--- a/healpix_convolution/padding.py
+++ b/healpix_convolution/padding.py
@@ -148,6 +148,7 @@ def pad(
     constant_value=0,
     end_value=0,
     reflect_type="even",
+    initial=0,
 ):
     """pad an array
 
@@ -177,6 +178,8 @@ def pad(
         The othermost value to interpolate to. Only used in linear ramp mode.
     reflect_type : {"even", "odd"}, default: "even"
         The reflect type. Only used in reflect mode.
+    initial : scalar, default: 0
+        The identity to use in maximum / minimum mode.
 
     Returns
     -------
@@ -217,8 +220,8 @@ def pad(
         "edge": edge_mode,
         "reflect_mode": partial(reflect_mode, reflect_type=reflect_type),
         "mean": partial(agg_mode, agg=np.mean, ring=ring),
-        "maximum": partial(agg_mode, agg=np.max, ring=ring),
-        "minimum": partial(agg_mode, agg=np.min, ring=ring),
+        "maximum": partial(agg_mode, agg=partial(np.max, initial=initial), ring=ring),
+        "minimum": partial(agg_mode, agg=partial(np.min, initial=initial), ring=ring),
         "median": partial(agg_mode, agg=np.median, ring=ring),
     }
 

--- a/healpix_convolution/padding.py
+++ b/healpix_convolution/padding.py
@@ -125,8 +125,9 @@ def agg_mode(cell_ids, neighbours, grid_info, *, agg, ring):
         indexing_scheme=grid_info.indexing_scheme,
         ring=ring,
     )
+    mask = np.isin(pad_neighbours, cell_ids)
 
-    data_indices = np.where(np.isin(pad_neighbours, cell_ids), pad_neighbours, -1)
+    data_indices = np.where(mask, np.searchsorted(cell_ids, pad_neighbours), -1)
     insert_indices = np.searchsorted(cell_ids, new_cell_ids)
 
     return AggregationPadding(

--- a/healpix_convolution/tests/test_padding.py
+++ b/healpix_convolution/tests/test_padding.py
@@ -120,6 +120,22 @@ class TestArray:
                 ),
                 id="constant-ring2-0",
             ),
+            pytest.param(
+                1,
+                "mean",
+                {},
+                np.array([163, 166, 167, 169, 171, 172, 173, 174, 175, 178, 184, 186]),
+                np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+                id="mean-ring1",
+            ),
+            pytest.param(
+                1,
+                "minimum",
+                {},
+                np.array([163, 166, 167, 169, 171, 172, 173, 174, 175, 178, 184, 186]),
+                np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+                id="minimum-ring1",
+            ),
         ),
     )
     def test_pad(self, dask, ring, mode, kwargs, expected_cell_ids, expected_data):


### PR DESCRIPTION
- [x] towards #25

This adds the `mean`, `minimum`, and `maximum` padding modes as aggregations. ~~Additionally, it also contains code for a `median` mode, but this is broken because `median` does not support the `where` parameter.~~ Fixed by moving to `nanreduce`, which also allows `dask` to work properly.

These modes are implemented by searching the neighbours of the padded cells. Depending on how costly this is, we might want to switch to grouping the neighbours of the input cells by the cell ids of the padded cells.