### PR TITLE
explicitly point to the configuration file on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,5 +16,6 @@ conda:
 
 sphinx:
   fail_on_warning: true
+  configuration: docs/conf.py
 
 formats: []


### PR DESCRIPTION
(readthedocs recently disabled building projects without that)