### PR TITLE
accept `HealpixInfo` objects in high-level functions

### DIFF
--- a/docs/user-guide/array.md
+++ b/docs/user-guide/array.md
@@ -32,8 +32,7 @@ We also need a kernel:
 ```{jupyter-execute}
 _, kernel = hc.kernels.gaussian_kernel(
     cell_ids,
-    resolution=grid_info.level,
-    indexing_scheme=grid_info.indexing_scheme,
+    grid_info=grid_info,
     sigma=0.5,
     kernel_size=5,
     weights_threshold=1e-8,
@@ -88,8 +87,7 @@ and we can immediately define the kernel:
 kernel_size = 5
 _, kernel = hc.kernels.gaussian_kernel(
     cell_ids,
-    resolution=grid_info.level,
-    indexing_scheme=grid_info.indexing_scheme,
+    grid_info=grid_info,
     sigma=0.5,
     kernel_size=kernel_size,
     weights_threshold=1e-10,

--- a/healpix_convolution/distances.py
+++ b/healpix_convolution/distances.py
@@ -37,17 +37,15 @@ def _distances(a, b, axis, nside, nest):
     return angle_between_vectors(vec_a, vec_b, axis=axis)
 
 
-def angular_distances(neighbours, *, resolution, indexing_scheme="nested", axis=None):
+def angular_distances(neighbours, *, grid_info, axis=None):
     """compute the angular great-circle distances between neighbours
 
     Parameters
     ----------
     neighbours : array-like
         The input cell ids.
-    resolution : int
-        The resolution of healpix pixelization.
-    indexing_scheme : {"nested", "ring"}, default: "nested"
-        The indexing scheme of the cell ids.
+    grid_info : xdggs.HealpixInfo
+        The grid parameters.
     axis : int, optional
         The axis used for the neighbours. If not given, assume the last dimension.
 
@@ -60,8 +58,8 @@ def angular_distances(neighbours, *, resolution, indexing_scheme="nested", axis=
     if axis is None:
         axis = -1
 
-    nest = indexing_scheme == "nested"
-    nside = 2**resolution
+    nest = grid_info.nest
+    nside = grid_info.nside
 
     if isinstance(neighbours, dask_array_type):
         return da.map_blocks(

--- a/healpix_convolution/kernels/gaussian.py
+++ b/healpix_convolution/kernels/gaussian.py
@@ -1,5 +1,6 @@
 import healpy as hp
 import numpy as np
+import xdggs
 
 from healpix_convolution.distances import angular_distances
 from healpix_convolution.kernels.common import create_sparse
@@ -31,8 +32,7 @@ def gaussian_function(distances, sigma, *, mask=None):
 def gaussian_kernel(
     cell_ids,
     *,
-    resolution: int,
-    indexing_scheme: str,
+    grid_info: xdggs.HealpixInfo,
     sigma: float,
     truncate: float = 4.0,
     kernel_size: int | None = None,
@@ -44,10 +44,8 @@ def gaussian_kernel(
     ----------
     cell_ids : array-like
         The cell ids.
-    resolution : int
-        The healpix resolution
-    indexing_scheme : {"nested", "ring"}
-        The healpix indexing scheme
+    grid_info : xdggs.HealpixInfo
+        The grid parameters.
     sigma : float
         The standard deviation of the gaussian function in radians.
     truncate : float, default: 4.0
@@ -73,12 +71,10 @@ def gaussian_kernel(
 
     cell_ids = np.reshape(cell_ids, (-1,))
 
-    ring = compute_ring(resolution, sigma, truncate, kernel_size)
+    ring = compute_ring(grid_info.level, sigma, truncate, kernel_size)
 
-    nb = neighbours(
-        cell_ids, resolution=resolution, indexing_scheme=indexing_scheme, ring=ring
-    )
-    d = angular_distances(nb, resolution=resolution, indexing_scheme=indexing_scheme)
+    nb = neighbours(cell_ids, grid_info=grid_info, ring=ring)
+    d = angular_distances(nb, grid_info=grid_info)
     weights = gaussian_function(d, sigma, mask=nb == -1)
 
     return create_sparse(cell_ids, nb, weights, weights_threshold)

--- a/healpix_convolution/neighbours.py
+++ b/healpix_convolution/neighbours.py
@@ -179,21 +179,21 @@ def minimum_dtype(value):
         return "int64"
 
 
-def neighbours(cell_ids, *, resolution, indexing_scheme, ring=1):
+def neighbours(cell_ids, *, grid_info, ring=1):
     """determine the neighbours within the nth ring around the center pixel
 
     Parameters
     ----------
-    resolution : int
-        The healpix resolution. Has to be within [0, 29].
     cell_ids : array-like
         The cell ids of which to find the neighbours.
+    grid_info : xdggs.HealpixInfo
+        The grid parameters.
     ring : int, default: 1
         The number of the ring. `ring=0` returns just the cell id, `ring=1` returns the 8
         (or 7) immediate neighbours, `ring=2` returns the 8 (or 7) immediate neighbours
         plus their immediate neighbours (a total of 24 cells), and so on.
     """
-    nside = 2**resolution
+    nside = grid_info.nside
     if ring < 0:
         raise ValueError(f"ring must be a positive integer or 0, got {ring}")
     if ring > nside:
@@ -210,12 +210,15 @@ def neighbours(cell_ids, *, resolution, indexing_scheme, ring=1):
             cell_ids,
             offsets=offsets,
             nside=nside,
-            indexing_scheme=indexing_scheme,
+            indexing_scheme=grid_info.indexing_scheme,
             new_axis=1,
             chunks=cell_ids.chunks + (n_neighbours,),
             dtype=cell_ids.dtype,
         )
     else:
         return _neighbours(
-            cell_ids, offsets=offsets, nside=nside, indexing_scheme=indexing_scheme
+            cell_ids,
+            offsets=offsets,
+            nside=nside,
+            indexing_scheme=grid_info.indexing_scheme,
         )

--- a/healpix_convolution/padding.py
+++ b/healpix_convolution/padding.py
@@ -156,8 +156,7 @@ def agg_mode(cell_ids, neighbours, grid_info, *, agg, ring):
 
     pad_neighbours = search_neighbours(
         new_cell_ids,
-        resolution=grid_info.level,
-        indexing_scheme=grid_info.indexing_scheme,
+        grid_info=grid_info,
         ring=ring,
     )
     mask = np.isin(pad_neighbours, cell_ids)
@@ -242,8 +241,7 @@ def pad(
     # plus a method to apply the padding to data.
     neighbours = search_neighbours(
         cell_ids,
-        resolution=grid_info.level,
-        indexing_scheme=grid_info.indexing_scheme,
+        grid_info=grid_info,
         ring=ring,
     )
 

--- a/healpix_convolution/padding.py
+++ b/healpix_convolution/padding.py
@@ -239,11 +239,7 @@ def pad(
     #   * an array of indices that map existing values to the new cell ids
     # To be able to reuse this, we need a set of dataclasses that can encapsulate that,
     # plus a method to apply the padding to data.
-    neighbours = search_neighbours(
-        cell_ids,
-        grid_info=grid_info,
-        ring=ring,
-    )
+    neighbours = search_neighbours(cell_ids, grid_info=grid_info, ring=ring)
 
     modes = {
         "constant": partial(constant_mode, constant_value=constant_value),

--- a/healpix_convolution/tests/test_distances.py
+++ b/healpix_convolution/tests/test_distances.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import xdggs
 
 import healpix_convolution.distances as hds
 
@@ -22,6 +23,7 @@ def test_angle_between_vectors():
     ),
 )
 def test_angular_distances_numpy(neighbours, expected):
-    actual = hds.angular_distances(neighbours, resolution=2, indexing_scheme="nested")
+    grid_info = xdggs.HealpixInfo(level=2, indexing_scheme="nested")
+    actual = hds.angular_distances(neighbours, grid_info=grid_info)
 
     np.testing.assert_allclose(actual, expected)

--- a/healpix_convolution/tests/test_neighbours.py
+++ b/healpix_convolution/tests/test_neighbours.py
@@ -3,6 +3,7 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 from hypothesis import given
+from xdggs import HealpixInfo
 
 from healpix_convolution.neighbours import generate_offsets, neighbours
 
@@ -37,14 +38,14 @@ def test_neighbours_ring1_manual(resolution, indexing_scheme, dask):
     else:
         xp = np
 
+    grid_info = HealpixInfo(level=resolution, indexing_scheme=indexing_scheme)
+
     cell_ids = xp.arange(12 * 4**resolution)
 
-    actual = neighbours(
-        cell_ids, resolution=resolution, indexing_scheme=indexing_scheme, ring=1
-    )
+    actual = neighbours(cell_ids, grid_info=grid_info, ring=1)
 
-    nside = 2**resolution
-    nest = indexing_scheme == "nested"
+    nside = grid_info.nside
+    nest = grid_info.nest
     expected = hp.get_all_neighbours(nside, np.asarray(cell_ids), nest=nest).T
 
     actual_ = np.asarray(actual[:, 1:])
@@ -56,11 +57,10 @@ def test_neighbours_ring1_manual(resolution, indexing_scheme, dask):
 def test_neighbours_ring1(resolution, indexing_scheme):
     cell_ids = np.arange(12 * 4**resolution)
 
-    actual = neighbours(
-        cell_ids, resolution=resolution, indexing_scheme=indexing_scheme, ring=1
-    )
-    nside = 2**resolution
-    nest = indexing_scheme == "nested"
+    grid_info = HealpixInfo(level=resolution, indexing_scheme=indexing_scheme)
+    actual = neighbours(cell_ids, grid_info=grid_info, ring=1)
+    nside = grid_info.nside
+    nest = grid_info.nest
     expected = hp.get_all_neighbours(nside, cell_ids, nest=nest).T
 
     np.testing.assert_equal(actual[:, 1:], expected)

--- a/healpix_convolution/xarray/kernels/gaussian.py
+++ b/healpix_convolution/xarray/kernels/gaussian.py
@@ -46,8 +46,7 @@ def gaussian_kernel(
 
     padded_cell_ids, matrix = gaussian.gaussian_kernel(
         cell_ids.data,
-        resolution=grid_info.level,
-        indexing_scheme=grid_info.indexing_scheme,
+        grid_info=grid_info,
         sigma=sigma,
         truncate=truncate,
         kernel_size=kernel_size,


### PR DESCRIPTION
`xdggs`' `HealpixInfo` objects are a good way of encapsulating the grid parameters. We already hard-depend on `xdggs` so that's not a big change, but if we decide to switch away from that, we could just accept any `namedtuple` / dataclass with `level`, `indexing_scheme`, `nside` and `nest` fields (in fact, due to duck-typing this should already work... should type hints ever become a concern we could just create a protocol for that).