### PR TITLE
RTD maintenance

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,8 @@
+# dependency configuration
+import matplotlib
+
+matplotlib.set_logger("critical")
+
 # -- Project information -----------------------------------------------------
 import datetime as dt
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # dependency configuration
 import matplotlib
 
-matplotlib.set_logger("critical")
+matplotlib.set_loglevel("critical")
 
 # -- Project information -----------------------------------------------------
 import datetime as dt


### PR DESCRIPTION
`sphinx` fails apparently because `matplotlib` warns about attempting to rebuild the font cache, which `sphinx` interprets as an actual warning.