### PR TITLE
fix several small bugs

### DIFF
--- a/healpix_convolution/kernels/gaussian.py
+++ b/healpix_convolution/kernels/gaussian.py
@@ -67,7 +67,7 @@ def gaussian_kernel(
     -----
     no dask support, yet
     """
-    if cell_ids.ndim != 1 or len([s for s in cell_ids.shape if s != 1]) != 1:
+    if cell_ids.ndim != 1 or len([s for s in cell_ids.shape if s != 1]) not in (0, 1):
         raise ValueError(
             f"cell ids must be 1-dimensional, but shape is: {cell_ids.shape}"
         )

--- a/healpix_convolution/padding.py
+++ b/healpix_convolution/padding.py
@@ -165,7 +165,7 @@ def agg_mode(cell_ids, neighbours, grid_info, *, agg, ring):
     insert_indices = np.searchsorted(cell_ids, new_cell_ids)
 
     return AggregationPadding(
-        cell_ids=all_cell_ids,
+        cell_ids=np.setdiff1d(all_cell_ids, np.array([-1])),
         insert_indices=insert_indices,
         grid_info=grid_info,
         agg=agg,

--- a/healpix_convolution/tests/test_kernels.py
+++ b/healpix_convolution/tests/test_kernels.py
@@ -206,6 +206,10 @@ class TestGaussian:
                     "kernel_size": 3,
                 },
             ),
+            (
+                np.array([1]),
+                {"level": 1, "indexing_scheme": "nested", "sigma": 0.1},
+            ),
         ),
     )
     def test_gaussian_kernel(self, cell_ids, kwargs):

--- a/healpix_convolution/tests/test_padding.py
+++ b/healpix_convolution/tests/test_padding.py
@@ -324,11 +324,17 @@ class TestXarray:
 
         ds = xr.Dataset(
             {"data": ("cells", data_)},
-            coords={"cell_ids": ("cells", cell_ids, grid_info.to_dict())},
+            coords={
+                "cell_ids": ("cells", cell_ids, grid_info.to_dict()),
+                "crs": ((), 0),
+            },
         ).pipe(xdggs.decode)
         expected_ds = xr.Dataset(
             {"data": ("cells", expected_data_)},
-            coords={"cell_ids": ("cells", expected_cell_ids, grid_info.to_dict())},
+            coords={
+                "cell_ids": ("cells", expected_cell_ids, grid_info.to_dict()),
+                "crs": ((), 0),
+            },
         ).pipe(xdggs.decode)
 
         if type_ is xr.Dataset:

--- a/healpix_convolution/tests/test_padding.py
+++ b/healpix_convolution/tests/test_padding.py
@@ -171,6 +171,14 @@ class TestArray:
         np.testing.assert_equal(padder.cell_ids, expected_cell_ids)
         np.testing.assert_equal(actual, expected_data)
 
+    def test_pad_corner(self):
+        grid_info = xdggs.healpix.HealpixInfo(level=1, indexing_scheme="nested")
+        cell_ids = np.array([2, 3], dtype="uint64")
+
+        padder = padding.pad(cell_ids, grid_info=grid_info, ring=1, mode="mean")
+
+        assert -1 not in padder.cell_ids
+
 
 class TestXarray:
     @pytest.mark.parametrize(

--- a/healpix_convolution/xarray/convolution.py
+++ b/healpix_convolution/xarray/convolution.py
@@ -59,9 +59,15 @@ def convolve(
         )
         ds = padder.apply(ds)
 
+    unrelated = ds.drop_vars(
+        [name for name, var in ds.variables.items() if "cells" in var.dims]
+    )
+
     return (
         ds.rename_dims({dim: "input_cells"})
         .map(_convolve, weights=kernel)
         .rename_dims({"output_cells": dim})
         .rename_vars({"output_cell_ids": "cell_ids"})
+        .merge(unrelated)
+        .dggs.decode()
     )

--- a/healpix_convolution/xarray/convolution.py
+++ b/healpix_convolution/xarray/convolution.py
@@ -47,7 +47,7 @@ def convolve(
             weights,
             # This dimension will be "contracted"
             # or summed over after multiplying by the weights
-            dims=src_dims,
+            dim=src_dims,
         )
 
     if ds.sizes["cells"] != kernel.sizes["input_cells"]:


### PR DESCRIPTION
This includes:

- don't include `-1` in the output cell ids of aggregation padding
- thread non-spatial variables through padding and convolution
- support 1-sized cell ids when creating kernels